### PR TITLE
fix: 'S4' is not subsettable and NbClust not found

### DIFF
--- a/R/circIMPACT_functions.R
+++ b/R/circIMPACT_functions.R
@@ -79,7 +79,6 @@ get.color.hues <- function(meta){
 marker.detection <- function(circ_id, circ.m, dds, sf, method.d, method.c, k, 
                              choose.k=FALSE, index.m = NULL, 
                              median=TRUE){
-  
   if(median){
     if(median(circ.m)==0){
       group <- ifelse(circ.m<mean(circ.m), "g1", "g2")
@@ -298,7 +297,7 @@ marker.selection <- function(dat, dds, sf, p.cutoff=0.01, lfc.cutoff=NULL, metho
   no_cores <- detectCores() - 5  
   registerDoParallel(cores=no_cores)  
   
-  circ_mark = foreach::foreach(i=1:nrow(dat)) %dopar% {
+  circ_mark = foreach::foreach(i=1:nrow(dat), .packages=c("DESeq2", "NbClust")) %dopar% {
     
     circ_id <- rownames(dat)[i]
     #make a for loop to estimate log2FC and p.adj to select marker circRNAs


### PR DESCRIPTION
Hi @AFBuratin!
I have experienced the same issue reported in #1. I am submitting to you this pull request with a quick fix for this issue.

The error was caused by a couple of things:
1) Reproducing the vignette code causes an error because `k,  method.c, method.d` are missing in the `marker.selection` example. After fixing this first issue, another error appears:
2) "Object of type 'S4' is not subsettable". This was caused by the parallelization of the `foreach` in the `marker.selection` function (circIMPACT_functions.R). According to [Stack Overflow](https://stackoverflow.com/questions/35090327/r-object-of-type-s4-is-not-subsettable-when-using-foreach-loop), this is common when the packages aren't loaded in the foreach loop. So I just added a `.packages=c("DESeq2", "NbClust")` inside the foreach and all good.

You can test this alteration with the following code:
```R
library(devtools)
load_all('./R')
library(DESeq2)
library(data.table)
library(plyr)
library(Rtsne)
library(ggplot2)
library(ggrepel)
library(plotly)
library(ComplexHeatmap)
library(circlize)
library(viridis)
library(knitr)
library(kableExtra)
library(formattable)
library(htmltools)
library(sparkline)
library(tidyverse)
library(RColorBrewer)
library(purrr)
library(magrittr)
library(randomForest)
library(DaMiRseq)
library(webshot)
library(ggpubr)
library(tidyr)
library(factoextra)
library(NbClust)
library(doParallel)

data("circularData")
data("count.matrix")
data("meta")
data("coldata.df")

## define sample/condition colors
intgroup.dt <- meta[, .(.N), by = .(sample, 
                                      condition)][order(sample), 
                                                  .(sample), by = condition]
samples.per.condition <- data.frame(intgroup.dt[, .N, by = .(condition)], row.names = "condition")
  
n.conditions <- nrow(samples.per.condition)
hues <- circIMPACT::gg_color_hue(n.conditions)
for(i in 1:n.conditions){
      n.hues <- samples.per.condition[i, "N"] + 2
      col.hues <- colorRampPalette(colors = c(hues[i], 
                                              "white"))(n.hues)[1:(n.hues-2)]
      
      intgroup.dt[condition == rownames(samples.per.condition)[i], `:=`(color = col.hues,
                                                                        hue = hues[i])]
    }
## create a deseq dataset object 
dds.circular <- suppressMessages(DESeqDataSetFromMatrix(countData = ceiling(circularData[, coldata.df$sample[order(coldata.df$condition)]]),
                                   colData = coldata.df[order(coldata.df$condition),],
                                   design = ~ condition))
dds.circular <- suppressMessages(estimateSizeFactors(dds.circular))
sf <- sizeFactors(dds.circular)

data.filt <- circularData[rowSums(circularData >= 10) >= 2,]
dds.filt.expr <- suppressMessages(DESeqDataSetFromMatrix(countData = ceiling(data.filt[,coldata.df$sample[order(coldata.df$condition)]]),
                                   colData = coldata.df[order(coldata.df$condition),],
                                   design = ~ condition))
dds.filt.expr <- suppressMessages(estimateSizeFactors(dds.filt.expr))
sf.filt <- sizeFactors(dds.filt.expr)
circNormDeseq <- counts(dds.filt.expr, normalized = T)

circIMPACT <- circIMPACT::marker.selection(dat = circNormDeseq, 
                               dds = dds.filt.expr, 
                               sf = sf.filt, p.cutoff = 0.05, lfc.cutoff = 1, k=2, method.c = "kmeans", method.d="euclidean")

circIMPACT_Kmeans <- marker.selection(dat = circNormDeseq,
                                      dds = dds.filt.expr,
                                      sf = sf.filt, p.cutoff = 0.05, lfc.cutoff = NULL, 
                                      method.d = "euclidean", method.c = "ward.D2",
                                      median = FALSE, choose.k = TRUE, index.m = "silhouette", k=2)
```

I hope this can help. Thank you and the other authors for this great package!